### PR TITLE
const t_symbol* for highly-used function args

### DIFF
--- a/source/c74support/jit-includes/jit.max.h
+++ b/source/c74support/jit-includes/jit.max.h
@@ -106,13 +106,13 @@ t_jit_err max_jit_obex_proxy_deletetail(void *x);
 t_jit_err max_jit_obex_proxy_append(void *x, long c);
 void max_jit_obex_dumpout_set(void *x, void *outlet);
 void *max_jit_obex_dumpout_get(void *x);
-void max_jit_obex_dumpout(void *x, t_symbol *s, short argc, t_atom *argv);
+void max_jit_obex_dumpout(void *x, const t_symbol *s, short argc, const t_atom *argv);
 void *max_jit_obex_adornmentlist_get(void *x);
 void max_jit_obex_adornmentlist_set(void *x, void *adornmentlist);
 void *max_jit_obex_adornment_get(void *x, t_symbol *classname);
 t_jit_err max_jit_obex_addadornment(void *x,void *adornment);
-void max_jit_obex_gimmeback(void *x, t_symbol *s, long ac, t_atom *av);
-void max_jit_obex_gimmeback_dumpout(void *x, t_symbol *s, long ac, t_atom *av);
+void max_jit_obex_gimmeback(void *x, const t_symbol *s, long ac, const t_atom *av);
+void max_jit_obex_gimmeback_dumpout(void *x, const t_symbol *s, long ac, const t_atom *av);
 
 t_atom_long max_jit_method_is_attr(void *x, t_symbol *s);
 t_atom_long max_jit_method_is_undocumented(void *x, t_symbol *s);

--- a/source/c74support/max-includes/ext_obex.h
+++ b/source/c74support/max-includes/ext_obex.h
@@ -1203,7 +1203,7 @@ t_hashtab *object_obex_enforce(void *x);
 	@return 		This function returns the error code #MAX_ERR_NONE if successful, 
 	 				or one of the other error codes defined in #e_max_errorcodes if unsuccessful.
 */
-void object_obex_dumpout(void *x, t_symbol *s, long argc, t_atom *argv);
+void object_obex_dumpout(void *x, const t_symbol *s, long argc, const t_atom *argv);
 
 
 // DO NOT CALL THIS -- It is called automatically now from object_free() or freeobject() -- calling this will cause problems.
@@ -1256,7 +1256,7 @@ t_max_err atom_setfloat(t_atom *a, double b);
 	@return 		This function returns the error code #MAX_ERR_NONE if successful, 
 	 				or one of the other error codes defined in #e_max_errorcodes if unsuccessful.
 */
-t_max_err atom_setsym(t_atom *a, t_symbol *b);				
+t_max_err atom_setsym(t_atom *a, const t_symbol *b);				
 #endif
 
 

--- a/source/c74support/max-includes/ext_proto.h
+++ b/source/c74support/max-includes/ext_proto.h
@@ -167,7 +167,7 @@ void freeobject(t_object *op);
 	tables. See the source code for the coll object for an example of using a 
 	privately defined class. 
 */
-void *newinstance(t_symbol *s, short argc, t_atom *argv);
+void *newinstance(const t_symbol *s, short argc, const t_atom *argv);
 
 
 /**
@@ -873,7 +873,7 @@ void *outlet_list(void *o, t_symbol *s, short ac, t_atom *av);
 					the selector argument. Use the outlet_list() function instead. 
 */
 #ifndef outlet_anything
-void *outlet_anything(void *o, t_symbol *s, short ac, t_atom *av);
+void *outlet_anything(void *o, const t_symbol *s, short ac, const t_atom *av);
 #endif
 
 


### PR DESCRIPTION
`outlet_anything()`, `atom_setsym()` and making their t_symbol* `const` was the primary reason for this PR. Casting everywhere in my code is poor form.

* I did a regex and there are hundreds of other function signatures in which their t_symbol* can also be `const`.
* All the globals like `_jit_sym_char` should be const.
* It is likely many `t_atom* argv` in function signatures can also be `const`

### Workaround

One can workaround the missing `const` on some of these by using the `#ifndef`