### PR TITLE
Enable optimizations for USESYM()

### DIFF
--- a/source/c74support/max-includes/ext_obex_util.h
+++ b/source/c74support/max-includes/ext_obex_util.h
@@ -11,8 +11,10 @@
 BEGIN_USING_C_LINKAGE
 
 // symbol macros which may be swapped to use common symbol pointers for performance
+#ifndef USESYM
 #define USESYM(x)	gensym(#x)
 //#define USESYM(x)	_sym_##x
+#endif
 
 // macros for attributes
 // class attributes are almost universally attr_offset, except for class static attributes

--- a/source/c74support/max-includes/jpatcher_utils.h
+++ b/source/c74support/max-includes/jpatcher_utils.h
@@ -11,10 +11,8 @@ BEGIN_USING_C_LINKAGE
 					Note that this array must already by allocated using sysmem_newptr() or atom_alloc(). */
 void atom_copy(long argc1, t_atom *argv1, t_atom *argv2);
 
-/**	Print the contents of an array of atoms to the Max window.
-	@ingroup		atom
-	@param	argc	The count of atoms in argv.
-	@param	argv	The address to the first of an array of atoms.	*/
+//	Print the contents of an array of atoms to the Max window.
+//	Internal C74 use only.
 void postargs(long argc, t_atom *argv);
 
 /**	Print the contents of a dictionary to the Max window.


### PR DESCRIPTION
Enable consumer of SDK to define USESYM themselves before the SDK header is loaded. This can be used to optimize lookup/generation of symbols.

### Example

```cpp
#define USESYM(x) _sym_##x
#include "ext.h"
#include "ext_obex.h"
```

This example allows the Max SDK itself to use the common symbols if they have been initialized before using the dependent parts of the SDK.

### Important caution

If you use the above optimization and you need the obex macros `CLASS_ATTR_ATOM_LONG()` and `CLASS_ATTR_ATOM_LONG_ARRAY()`, then you will need to declare/generate your own global for `_sym_atom_long`. This common sym is missing from the Max headers/libraries distributed with this SDK.

This common sym needs to be added to the Max header/libraries for completeness. In the interim, an SDK user can easily gensym() their own global _sym_atom_long if you need those two macros. For example in pseudocode:

```cpp
t_symbol *_sym_atom_long;

ext_main() {
  _sym_atom_long = gensym("atom_long");
}
```

or C++11
```cpp
const t_symbol * const _sym_atom_long { gensym("atom_long") };
```