### PR TITLE
Add missing macOS header

### DIFF
--- a/source/c74support/max-includes/ext_critical.h
+++ b/source/c74support/max-includes/ext_critical.h
@@ -12,7 +12,7 @@ BEGIN_USING_C_LINKAGE
 #endif
 
 #ifdef MAC_VERSION
-
+#include <Multiprocessing.h>
 typedef MPCriticalRegionID t_critical;	///< a critical region  @ingroup critical
 	
 #endif // MAC_VERSION


### PR DESCRIPTION
Hello,
for some reason while updating I'm now missing this header when building externals (clang was complaining about MPCriticalRegionID not being defined).