### PR TITLE
Fix include on macOS 11.0

### DIFF
--- a/source/c74support/max-includes/ext_critical.h
+++ b/source/c74support/max-includes/ext_critical.h
@@ -12,7 +12,6 @@ BEGIN_USING_C_LINKAGE
 #endif
 
 #ifdef MAC_VERSION
-#include <Multiprocessing.h>
 typedef MPCriticalRegionID t_critical;	///< a critical region  @ingroup critical
 	
 #endif // MAC_VERSION

--- a/source/c74support/max-includes/ext_path.h
+++ b/source/c74support/max-includes/ext_path.h
@@ -206,7 +206,7 @@ short path_getsupportpath(void);
 #ifdef MAC_VERSION
 
 #ifndef __FILES__
-#include <Files.h>
+#include <Carbon/Carbon.h>
 #endif // __FILES__
 	
 short path_tofsref(C74_CONST short path, C74_CONST char *filename, FSRef *ref);


### PR DESCRIPTION
recently I have to change those include to make it build on macOS 11.0

it still build fine on older version.