### PR TITLE
Changed path in CMakeLists.txt files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source/max-sdk-base"]
 	path = source/max-sdk-base
-	url = https://github.com/Cycling74/max-sdk-base
+	url = https://github.com/bachfamily/max-sdk-base

--- a/source/advanced/collect/CMakeLists.txt
+++ b/source/advanced/collect/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/dbcuelist/CMakeLists.txt
+++ b/source/advanced/dbcuelist/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/dbviewer/CMakeLists.txt
+++ b/source/advanced/dbviewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -22,4 +22,4 @@ add_library(
 	${MAX_SDK_INCLUDES}/common/commonsyms.c
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/filebyte/CMakeLists.txt
+++ b/source/advanced/filebyte/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/linky/CMakeLists.txt
+++ b/source/advanced/linky/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/simpleparallel/CMakeLists.txt
+++ b/source/advanced/simpleparallel/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/simplethread/CMakeLists.txt
+++ b/source/advanced/simplethread/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/advanced/threadpool/CMakeLists.txt
+++ b/source/advanced/threadpool/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/dspstress~/CMakeLists.txt
+++ b/source/audio/dspstress~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/fftinfo~/CMakeLists.txt
+++ b/source/audio/fftinfo~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/index~/CMakeLists.txt
+++ b/source/audio/index~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/lores~/CMakeLists.txt
+++ b/source/audio/lores~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/pictmeter~/CMakeLists.txt
+++ b/source/audio/pictmeter~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/plussz~/CMakeLists.txt
+++ b/source/audio/plussz~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/simplemsp~/CMakeLists.txt
+++ b/source/audio/simplemsp~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/simpwave~/CMakeLists.txt
+++ b/source/audio/simpwave~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/split~/CMakeLists.txt
+++ b/source/audio/split~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/audio/times~/CMakeLists.txt
+++ b/source/audio/times~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/attrtester/CMakeLists.txt
+++ b/source/basics/attrtester/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/delay2/CMakeLists.txt
+++ b/source/basics/delay2/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/dummy/CMakeLists.txt
+++ b/source/basics/dummy/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/plussz/CMakeLists.txt
+++ b/source/basics/plussz/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/plussz2/CMakeLists.txt
+++ b/source/basics/plussz2/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/simplejs/CMakeLists.txt
+++ b/source/basics/simplejs/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/simplemax/CMakeLists.txt
+++ b/source/basics/simplemax/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/simpletext/CMakeLists.txt
+++ b/source/basics/simpletext/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/basics/urner/CMakeLists.txt
+++ b/source/basics/urner/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/dictionary/dict.group/CMakeLists.txt
+++ b/source/dictionary/dict.group/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/dictionary/dict.route/CMakeLists.txt
+++ b/source/dictionary/dict.route/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/dictionary/dict.strip/CMakeLists.txt
+++ b/source/dictionary/dict.strip/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/gl/jit.gl.cube/CMakeLists.txt
+++ b/source/gl/jit.gl.cube/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/gl/jit.gl.gridshape/CMakeLists.txt
+++ b/source/gl/jit.gl.gridshape/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/gl/jit.gl.simple/CMakeLists.txt
+++ b/source/gl/jit.gl.simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/gl/jit.gl.videoplane/CMakeLists.txt
+++ b/source/gl/jit.gl.videoplane/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.3m/CMakeLists.txt
+++ b/source/matrix/jit.3m/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.alphablend/CMakeLists.txt
+++ b/source/matrix/jit.alphablend/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.change/CMakeLists.txt
+++ b/source/matrix/jit.change/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.charmap/CMakeLists.txt
+++ b/source/matrix/jit.charmap/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.clip/CMakeLists.txt
+++ b/source/matrix/jit.clip/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.coerce/CMakeLists.txt
+++ b/source/matrix/jit.coerce/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.concat/CMakeLists.txt
+++ b/source/matrix/jit.concat/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.demultiplex/CMakeLists.txt
+++ b/source/matrix/jit.demultiplex/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.dimmap/CMakeLists.txt
+++ b/source/matrix/jit.dimmap/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.eclipse/CMakeLists.txt
+++ b/source/matrix/jit.eclipse/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.fill/CMakeLists.txt
+++ b/source/matrix/jit.fill/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.findbounds/CMakeLists.txt
+++ b/source/matrix/jit.findbounds/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.fluoride/CMakeLists.txt
+++ b/source/matrix/jit.fluoride/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.glue/CMakeLists.txt
+++ b/source/matrix/jit.glue/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.gradient/CMakeLists.txt
+++ b/source/matrix/jit.gradient/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.hello/CMakeLists.txt
+++ b/source/matrix/jit.hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.histogram/CMakeLists.txt
+++ b/source/matrix/jit.histogram/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.iter/CMakeLists.txt
+++ b/source/matrix/jit.iter/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.keyscreen/CMakeLists.txt
+++ b/source/matrix/jit.keyscreen/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.la.diagproduct/CMakeLists.txt
+++ b/source/matrix/jit.la.diagproduct/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.noise/CMakeLists.txt
+++ b/source/matrix/jit.noise/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.notify/CMakeLists.txt
+++ b/source/matrix/jit.notify/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.op/CMakeLists.txt
+++ b/source/matrix/jit.op/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.p.bounds/CMakeLists.txt
+++ b/source/matrix/jit.p.bounds/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.pack/CMakeLists.txt
+++ b/source/matrix/jit.pack/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.peek~/CMakeLists.txt
+++ b/source/matrix/jit.peek~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.poke~/CMakeLists.txt
+++ b/source/matrix/jit.poke~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.print/CMakeLists.txt
+++ b/source/matrix/jit.print/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.rgb2luma/CMakeLists.txt
+++ b/source/matrix/jit.rgb2luma/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.scalebias/CMakeLists.txt
+++ b/source/matrix/jit.scalebias/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.scissors/CMakeLists.txt
+++ b/source/matrix/jit.scissors/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.spill/CMakeLists.txt
+++ b/source/matrix/jit.spill/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.split/CMakeLists.txt
+++ b/source/matrix/jit.split/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.str.op/CMakeLists.txt
+++ b/source/matrix/jit.str.op/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -23,4 +23,4 @@ add_library(
 	max.jit.str.op.c
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.submatrix/CMakeLists.txt
+++ b/source/matrix/jit.submatrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.textfile/CMakeLists.txt
+++ b/source/matrix/jit.textfile/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.thin/CMakeLists.txt
+++ b/source/matrix/jit.thin/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.transpose/CMakeLists.txt
+++ b/source/matrix/jit.transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.turtle/CMakeLists.txt
+++ b/source/matrix/jit.turtle/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/jit.unpack/CMakeLists.txt
+++ b/source/matrix/jit.unpack/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/simplejit/CMakeLists.txt
+++ b/source/matrix/simplejit/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/matrix/simplejit~/CMakeLists.txt
+++ b/source/matrix/simplejit~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/mc/gridmeter~/CMakeLists.txt
+++ b/source/mc/gridmeter~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -22,4 +22,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/mc/limi~/CMakeLists.txt
+++ b/source/mc/limi~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/mc/mc.pack~/CMakeLists.txt
+++ b/source/mc/mc.pack~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -22,4 +22,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/mc/mc.rotate~/CMakeLists.txt
+++ b/source/mc/mc.rotate~/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/buddy/CMakeLists.txt
+++ b/source/misc/buddy/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/filedate/CMakeLists.txt
+++ b/source/misc/filedate/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/filein/CMakeLists.txt
+++ b/source/misc/filein/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/folder/CMakeLists.txt
+++ b/source/misc/folder/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/iter/CMakeLists.txt
+++ b/source/misc/iter/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/master/CMakeLists.txt
+++ b/source/misc/master/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/match/CMakeLists.txt
+++ b/source/misc/match/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/minimum/CMakeLists.txt
+++ b/source/misc/minimum/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/past/CMakeLists.txt
+++ b/source/misc/past/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/servant/CMakeLists.txt
+++ b/source/misc/servant/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/thresh/CMakeLists.txt
+++ b/source/misc/thresh/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/vexpr/CMakeLists.txt
+++ b/source/misc/vexpr/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/misc/windowwatcher/CMakeLists.txt
+++ b/source/misc/windowwatcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/howbigisyourp/CMakeLists.txt
+++ b/source/patcher/howbigisyourp/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/iterate2/CMakeLists.txt
+++ b/source/patcher/iterate2/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/iterator/CMakeLists.txt
+++ b/source/patcher/iterator/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/scripto/CMakeLists.txt
+++ b/source/patcher/scripto/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/sheep/CMakeLists.txt
+++ b/source/patcher/sheep/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/shepherd/CMakeLists.txt
+++ b/source/patcher/shepherd/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/patcher/whosyourdaddy/CMakeLists.txt
+++ b/source/patcher/whosyourdaddy/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/ui/jslider/CMakeLists.txt
+++ b/source/ui/jslider/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -22,4 +22,4 @@ add_library(
 	${MAX_SDK_INCLUDES}/common/commonsyms.c
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/ui/uioptimized/CMakeLists.txt
+++ b/source/ui/uioptimized/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/ui/uires/CMakeLists.txt
+++ b/source/ui/uires/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/ui/uisimp/CMakeLists.txt
+++ b/source/ui/uisimp/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	uisimp.c
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/ui/uitester/CMakeLists.txt
+++ b/source/ui/uitester/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -21,4 +21,4 @@ add_library(
 	${PROJECT_SRC}
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)

--- a/source/ui/uitextfield/CMakeLists.txt
+++ b/source/ui/uitextfield/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-pretarget.cmake)
 
 #############################################################
 # MAX EXTERNAL
@@ -22,4 +22,4 @@ add_library(
 	${MAX_SDK_INCLUDES}/common/jpatcher_syms.c
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../max-sdk/source/max-sdk-base/script/max-posttarget.cmake)


### PR DESCRIPTION
I changed the paths in the CMakeLists.txt files for each external project in the source folder, so as to make it easier to create new packages based upon the Max sdk. It is now sufficient to create a new package with a directory structure similar to that of the Max sdk; copy the CMakeLists.txt from max-sdk; copy any project directory, such as source/basics/simplemax; modify the file names; and run cmake from there.